### PR TITLE
ci, img build: build a latest image

### DIFF
--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ env.git_commit_hash }}
+          tags: ghcr.io/${{ github.repository }}:latest
           file: Dockerfile
 
       - name: Push stable container image


### PR DESCRIPTION
This way, we're more efficient with the size of the registry.