### PR TITLE
bug, config: fix RBAC to allow IPAMClaim updates

### DIFF
--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -119,6 +119,7 @@ rules:
   - ipamclaims
   verbs:
   - create
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
When PR #12 was added, we forgot to generate the new installer manifests.

This commit generates them.

Fixes #15 